### PR TITLE
Compile C/C++ examples on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,28 +23,38 @@ jobs:
           #  os: ubuntu-16.04
           #  compiler: gcc
           #  cpp-compiler: g++
+          #  build-dir: build
+          #  build-src-dir: ..
 
           #- name: Ubuntu 16.04 Clang
           #  os: ubuntu-16.04
           #  compiler: clang
           #  cpp-compiler: clang++
           #  packages: llvm-3.5
+          #  build-dir: build
+          #  build-src-dir: ..
 
           - name: Ubuntu 18.04 GCC
             os: ubuntu-18.04
             compiler: gcc
             cpp-compiler: g++
+            build-dir: build
+            build-src-dir: ..
 
           - name: Ubuntu 18.04 Clang
             os: ubuntu-18.04
             compiler: clang
             cpp-compiler: clang++
             packages: llvm-3.9
+            build-dir: build
+            build-src-dir: ..
 
           - name: Windows 2019 MSVC
             os: windows-2019
             compiler: cl
             cmake-args: -DBUILD_SHARED_LIBS=OFF -Dgtest_force_shared_crt=on
+            build-dir: build
+            build-src-dir: ..
 
           # - name: Windows 2019 GCC
           #   os: windows-2019
@@ -56,11 +66,15 @@ jobs:
             os: macOS-latest
             compiler: gcc
             cpp-compiler: g++
+            build-dir: build
+            build-src-dir: ..
 
           - name: macOS 10.15 Clang
             os: macOS-latest
             compiler: clang
             cpp-compiler: clang++
+            build-dir: build
+            build-src-dir: ..
 
     runs-on: ${{ matrix.os }}
 
@@ -93,13 +107,39 @@ jobs:
 
       - name: Compile source code
         run: |
-          cd ${{ matrix.build-src-dir || '.' }}
+          cd ${{ matrix.build-dir || '.' }}
           cmake --build . --config ${{ matrix.build-config || 'Release' }}
 
       - name: Run test cases
         run: |
           cd ${{ matrix.build-dir || '.' }}
           ctest -C ${{ matrix.build-config || 'Release' }} --output-on-failure
+
+      - name: Compile C examples
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: |
+          cd examples/code-samples/c
+          cmake .
+          cmake --build .
+        env:
+          CC: ${{ matrix.compiler }}
+          CXX: ${{ matrix.cpp-compiler }}
+          CFLAGS: ${{ matrix.cflags || env.CFLAGS }}
+          CXXFLAGS: ${{ matrix.cxxflags || env.CXXFLAGS }}
+          LDFLAGS: ${{ matrix.ldflags || env.LDFLAGS }}
+
+      - name: Compile C++ examples
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: |
+          cd examples/code-samples/cpp
+          cmake .
+          cmake --build .
+        env:
+          CC: ${{ matrix.compiler }}
+          CXX: ${{ matrix.cpp-compiler }}
+          CFLAGS: ${{ matrix.cflags || env.CFLAGS }}
+          CXXFLAGS: ${{ matrix.cxxflags || env.CXXFLAGS }}
+          LDFLAGS: ${{ matrix.ldflags || env.LDFLAGS }}
 
   docs:
     name: Build docs

--- a/examples/code-samples/c/05_DownloadModfile.c
+++ b/examples/code-samples/c/05_DownloadModfile.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-bool wait = true;
+bool _wait = true;
 
 void onDownloadMod(u32 response_code, u32 mod_id)
 {
@@ -15,7 +15,7 @@ void onDownloadMod(u32 response_code, u32 mod_id)
     modioInstallDownloadedMods();
     printf("Finished installing mods\n");
   }
-  wait = false;
+  _wait = false;
 }
 
 int main(void)
@@ -34,7 +34,7 @@ int main(void)
   // To download the mod we only have to provide it's id
   modioDownloadMod(mod_id);
 
-  while (wait)
+  while (_wait)
   {
     // While a mod is being downloaded, we can track it's progress by using the mod download queue related functions
     u32 queue_size = modioGetModDownloadQueueCount();

--- a/examples/code-samples/c/10_AddModfile.c
+++ b/examples/code-samples/c/10_AddModfile.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-bool wait = true;
+bool _wait = true;
 
 void onAddModfile(u32 response_code, u32 mod_id)
 {
@@ -13,7 +13,7 @@ void onAddModfile(u32 response_code, u32 mod_id)
   {
     printf("Modfile added!\n");
   }
-  wait = false;
+  _wait = false;
 }
 
 int main(void)
@@ -49,7 +49,7 @@ int main(void)
   modioAddModfile(mod_id, modfile_creator);
   modioFreeModfileCreator(&modfile_creator);
 
-  while (wait)
+  while (_wait)
   {
     // While a mod is being uploaded, we can track it's progress by using the mod upload queue related functions
     u32 queue_size = modioGetModfileUploadQueueCount();

--- a/examples/code-samples/c/CMakeLists.txt
+++ b/examples/code-samples/c/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
+project(examples)
 include_directories(../../../include)
 link_directories(../../../build)
 

--- a/examples/code-samples/cpp/CMakeLists.txt
+++ b/examples/code-samples/cpp/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
+project(examples)
 include_directories(../../../include)
 include_directories(../../../additional_dependencies)
 set (CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
Changed the jobs to build in the `build` directory because the code & project examples expect this location as link directory.

The examples build is excluded from Windows because the build artifacts are in `<build-dir>\Release\` and i don't know the best way to fix that.