### PR TITLE
[Fix] exception message wrapper could not compile in Unreal Engine.

### DIFF
--- a/modio/modio/detail/AsioWrapper.h
+++ b/modio/modio/detail/AsioWrapper.h
@@ -25,7 +25,7 @@ namespace asio
 		template<typename Exception>
 		void throw_exception(const Exception& e)
 		{
-			checkf(false, TEXT("Asio threw a exception with the message %s"), *e.what());
+			checkf(false, TEXT("Asio threw a exception with the message %hs"), e.what());
 		}
 
 	} // namespace detail


### PR DESCRIPTION
Firstly, `std::exception.what()` returns `char* const`, using a `*` to get its value from the address is meaningless. 

Secondly, Unreal Engine uses `TCHAR*` (aka. `wchar_t*`) on the MSVC compiler. The `checkf` macros only accept `%hs` as an escape character.

(Currently, I don't have the ability to test compatibility on other platforms, that includes Linux, MacOS, etc. Please merge this fix carefully.)